### PR TITLE
add logic to query real go get vcs url

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -77,7 +77,11 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = [
+    "context",
+    "html",
+    "html/atom"
+  ]
   revision = "dc948dff8834a7fe1ca525f8d04e261c2b56e70d"
 
 [[projects]]
@@ -95,6 +99,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "11fb1d938b87e4023449fc520059b14be6ac2f356e580ad0e65325b489d474e9"
+  inputs-digest = "a317572c6678a0a7322ac0c531cf3f8bc12c055c48d24411227b930158a2f8bc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/deps.nix
+++ b/deps.nix
@@ -78,7 +78,7 @@
         type = "git";
         url = "https://github.com/nightlyone/lockfile";
         rev =  "6a197d5ea61168f2ac821de2b7f011b250904900";
-        sha256 = "0z3bdl5hb7nq2pqx7zy0r47bcdvjw0y11jjphv7k0s09ahlnac29";
+        sha256 = "03znnf6rzyyi4h4qj81py1xpfs3pnfm39j4bfc9qzakz5j9y1gdl";
       };
     }
     

--- a/main.go
+++ b/main.go
@@ -62,10 +62,19 @@ func FindRealPath(url string) (string, error) {
 			}
 
 			// Extract vcs url
-			for idx, a := range t.Attr {
-				// makes (bad?) assumption content key is after name key
-				if a.Key == "name" && a.Val == "go-import" && t.Attr[idx+1].Key == "content" {
-					content := strings.Fields(t.Attr[idx+1].Val)
+			for _, a := range t.Attr {
+				if a.Key == "name" && a.Val == "go-import" {
+					var content []string
+					for _, b := range t.Attr {
+						if b.Key == "content" {
+							content = strings.Fields(b.Val)
+						}
+					}
+
+					if len(content) < 3 {
+						return "", fmt.Errorf("could not find content attribute for meta tag")
+					}
+
 					// go help importpath
 					// content[0] : original import path
 					// content[1] : vcs type

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 
-
-
 	"golang.org/x/net/html"
 )
 

--- a/main.go
+++ b/main.go
@@ -96,7 +96,6 @@ func FindRealPath(url string) (string, error) {
 func IsCommonPath(url string) bool {
 	// from `go help importpath`
 	commonPaths := [...]string{
-		"golang.org",
 		"bitbucket.org",
 		"github.com",
 		"launchpad.net",
@@ -182,9 +181,9 @@ func main() {
 		}
 
 		// special case: exception for golang.org/x based dependencies
-		if strings.Contains(t.Name, "golang.org/x/") {
-			url = "https://" + strings.Replace(t.Name, "golang.org/x/", "go.googlesource.com/", 1)
-		}
+		// if strings.Contains(t.Name, "golang.org/x/") {
+		// 	url = "https://" + strings.Replace(t.Name, "golang.org/x/", "go.googlesource.com/", 1)
+		// }
 
 		if url == "" {
 			url = "https://" + t.Name

--- a/main.go
+++ b/main.go
@@ -10,13 +10,16 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/pelletier/go-toml"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/pelletier/go-toml"
+	"golang.org/x/net/html"
 )
 
 var (
@@ -30,6 +33,73 @@ var (
 	inputFileFlag  = flag.String("i", "Gopkg.lock", "input lock file")
 	outputFileFlag = flag.String("o", "deps.nix", "output nix file")
 )
+
+// FindRealPath queries url to try to locate real vcs path
+func FindRealPath(url string) (string, error) {
+	// golang http client will follow redirects, so if http don't work should query https if 301 redirect
+	var resp *http.Response
+	resp, err := http.Get("http://" + url + "?go-get=1")
+	if err != nil {
+		return "", fmt.Errorf("Failed to query %v", url)
+	}
+	defer resp.Body.Close()
+
+	z := html.NewTokenizer(resp.Body)
+	for {
+		tt := z.Next()
+
+		switch {
+		case tt == html.ErrorToken:
+			// End of the document, we're done
+			return "", fmt.Errorf("end of body")
+		case tt == html.StartTagToken:
+			t := z.Token()
+
+			// Check if the token is an <meta> tag
+			isMeta := t.Data == "meta"
+			if !isMeta {
+				continue
+			}
+
+			// Extract vcs url
+			for idx, a := range t.Attr {
+				// makes (bad?) assumption content key is after name key
+				if a.Key == "name" && a.Val == "go-import" && t.Attr[idx+1].Key == "content" {
+					content := strings.Fields(t.Attr[idx+1].Val)
+					// go help importpath
+					// content[0] : original import path
+					// content[1] : vcs type
+					// content[2] : vcs url
+
+					// expand for non git vcs
+					if content[1] == "git" {
+						return content[2], nil
+					}
+					return "", fmt.Errorf("could not find git url")
+				}
+			}
+		}
+	}
+
+}
+
+// IsCommonPath checks to see if it's one of the common vcs locations go get supports
+func IsCommonPath(url string) bool {
+	// from `go help importpath`
+	commonPaths := [...]string{
+		"golang.org",
+		"bitbucket.org",
+		"github.com",
+		"launchpad.net",
+		"hub.jazz.net",
+	}
+	for _, path := range commonPaths {
+		if strings.Split(url, "/")[0] == path {
+			return true
+		}
+	}
+	return false
+}
 
 func main() {
 	flag.Parse()
@@ -90,8 +160,26 @@ func main() {
 
 		t := raw.Projects[i]
 
+		var url string
+		// check if it's a common git path `go get` supports and if not find real path
+		if !IsCommonPath(t.Name) {
+			realURL, err := FindRealPath(t.Name)
+
+			if err != nil {
+				//fmt.Printf("could not find real git url for import path %v: %+v\n", t.Name, err)
+				log.Fatal(err)
+			}
+			url = realURL
+		}
+
 		// special case: exception for golang.org/x based dependencies
-		url := "https://" + strings.Replace(t.Name, "golang.org/x/", "go.googlesource.com/", 1)
+		if strings.Contains(t.Name, "golang.org/x/") {
+			url = "https://" + strings.Replace(t.Name, "golang.org/x/", "go.googlesource.com/", 1)
+		}
+
+		if url == "" {
+			url = "https://" + t.Name
+		}
 
 		fmt.Println(" * Processing: \"" + t.Name + "\"")
 

--- a/main.go
+++ b/main.go
@@ -35,60 +35,15 @@ var (
 )
 
 // FindRealPath queries url to try to locate real vcs path
-// from `go help importpath`
-// ...
-// A few common code hosting sites have special syntax:
-//
-//         Bitbucket (Git, Mercurial)
-//
-//                 import "bitbucket.org/user/project"
-//                 import "bitbucket.org/user/project/sub/directory"
-//
-//         GitHub (Git)
-//
-//                 import "github.com/user/project"
-//                 import "github.com/user/project/sub/directory"
-//
-//         Launchpad (Bazaar)
-//
-//                 import "launchpad.net/project"
-//                 import "launchpad.net/project/series"
-//                 import "launchpad.net/project/series/sub/directory"
-//
-//                 import "launchpad.net/~user/project/branch"
-//                 import "launchpad.net/~user/project/branch/sub/directory"
-//
-//         IBM DevOps Services (Git)
-//
-//                 import "hub.jazz.net/git/user/project"
-//                 import "hub.jazz.net/git/user/project/sub/directory"
-//
-// ...
-// If the import path is not a known code hosting site and also lacks a
-// version control qualifier, the go tool attempts to fetch the import
-// over https/http and looks for a <meta> tag in the document's HTML
-// <head>.
-//
 // The meta tag has the form:
-//
 //         <meta name="go-import" content="import-prefix vcs repo-root">
-// ...
-// The repo-root is the root of the version control system
-// containing a scheme and not containing a .vcs qualifier.
 //
 // For example,
-//
 //         import "example.org/pkg/foo"
 //
 // will result in the following requests:
-//
 //         https://example.org/pkg/foo?go-get=1 (preferred)
 //         http://example.org/pkg/foo?go-get=1  (fallback, only with -insecure)
-//
-// If that page contains the meta tag
-//
-//         <meta name="go-import" content="example.org git https://code.org/r/p/exproj">b
-//
 func FindRealPath(url string) (string, error) {
 	// golang http client will follow redirects, so if http don't work should query https if 301 redirect
 	resp, err := http.Get("http://" + url + "?go-get=1")


### PR DESCRIPTION
you might want to run some thorough tests, I tested against a few Gopkg.lock files containing various google libs and it seems to work