### PR TITLE
prefetch: include git submodules

### DIFF
--- a/prefetch.go
+++ b/prefetch.go
@@ -37,7 +37,7 @@ func cmdStdout(command string, arguments ...string) (string, error) {
 type gitPrefetcher struct{}
 
 func (p *gitPrefetcher) fetchHash(url string, revision string) (string, error) {
-	out, err := cmdStdout("nix-prefetch-git", "--url", url, "--rev", revision, "--quiet")
+	out, err := cmdStdout("nix-prefetch-git", "--url", url, "--rev", revision, "--quiet", "--fetch-submodules")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

The submodule behaviour when pre-fetching must match the `fetchgit`
invocation in nixpkgs, which [currently defaults to true](https://github.com/NixOS/nixpkgs/blob/c6dcccc4029ed429325af1d9e3341e35acf7ee0b/pkgs/build-support/fetchgit/default.nix#L16).

I believe this is the cause of the [issue in the readme](https://github.com/nixcloud/dep2nix/blob/b5ad8b6a59b7865a90393b1ec004105ea37816ae/README.md#building-the-source) about "wrong hashes". The `fetchgit` call fetched the submodules and produced the correct hash, which correctly failed. The manual `nix-prefetch-git` call without submodules populated the store with a different fixed-output result, that was then used without `fetchgit` having to produce any output.

## Reasoning

When trying to package gocryptfs 1.6.1, I encountered the following error:

```
$ dep2nix
[ ... ]

$ grep -A3 tesoro deps.nix                                                                                                                                             ~/src/gocryptfs
    goPackagePath  = "github.com/conejoninja/tesoro";
    fetch = {
      type = "git";
      url = "https://github.com/conejoninja/tesoro";
      rev =  "e0e839b6a6f14bce56d1bfac9a86311a1646a6a3";
      sha256 = "10950nhknra2wbs0ka7lc5n5la86jrg3fa25sh2xpsp0gg09y42c";
    };

$ nix-build -A gocryptfs
[...]
fixed-output derivation produced path '/nix/store/n3hdigy7vsiyxnb8p2xn16nh8ryhn5xb-tesoro-e0e839b' with sha256 hash '19q1ibj6l6pk2a3iwcyrj60sscvkqw450psd9zdflvb293cjsx8v' instead of the expected hash '10950nhknra2wbs0ka7lc5n5la86jrg3fa25sh2xpsp0gg09y42c'
```

Digging deeper:

When running `nix-prefetch-git` with submodules, the result is in store path `/nix/store/n3hdigy7vsiyxnb8p2xn16nh8ryhn5xb-tesoro-e0e839b` with the following details:
```json
{
  "url": "https://github.com/conejoninja/tesoro",
  "rev": "e0e839b6a6f14bce56d1bfac9a86311a1646a6a3",
  "date": "2018-06-30T07:45:44+02:00",
  "sha256": "19q1ibj6l6pk2a3iwcyrj60sscvkqw450psd9zdflvb293cjsx8v",
  "fetchSubmodules": true
}
```

When fetching without, the result is in store path `/nix/store/inrbg68ab3qdv9mhzj28rx50j5sz5xr4-tesoro-e0e839b` with the following details:
```json
{
  "url": "https://github.com/conejoninja/tesoro",
  "rev": "e0e839b6a6f14bce56d1bfac9a86311a1646a6a3",
  "date": "2018-06-30T07:45:44+02:00",
  "sha256": "10950nhknra2wbs0ka7lc5n5la86jrg3fa25sh2xpsp0gg09y42c",
  "fetchSubmodules": false
}
```

Notice that the store path when fetching with submodules matches that of the failing `fetchgit` call.