### PR TITLE
Do not checkout repo if it's already present. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,8 +102,10 @@ func perform(logger *log.Logger) error {
 		}
 
 		// check out repository
-		if err := repo.Get(); err != nil {
-			return fmt.Errorf("error fetching project: %s", err.Error())
+		if !repo.CheckLocal() {
+			if err := repo.Get(); err != nil {
+				return fmt.Errorf("error fetching project: %s", err.Error())
+			}
 		}
 
 		// get resolved revision


### PR DESCRIPTION
This should solve #17

I have a project with the same problem and this fixes it for me.

There is alternative solution that removes `repo.LocalPath` directory before calling `repo.Get()`