### PR TITLE
End generated files with final newline

### DIFF
--- a/deps.go
+++ b/deps.go
@@ -36,7 +36,8 @@ func (d *Dep) toNix() string {
 const depsFileHeader = `# file generated from Gopkg.lock using dep2nix (https://github.com/nixcloud/dep2nix)
 [`
 const depsFileFooter = `
-]`
+]
+`
 
 type Deps []*Dep
 


### PR DESCRIPTION
Nixpkgs has a CI check that enforces this for Nix files.  Currently,
there's an exception made for dep2nix files, but it would be good if
that exception could be dropped and dep2nix-generated files followed
the same rules as everything else.