### PR TITLE
Don't use removed bin output in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ buildGoPackage rec {
   goDeps = ./deps.nix;
 
   postInstall = ''
-    wrapProgram $bin/bin/dep2nix --prefix PATH ':' ${binPath}
+    wrapProgram $out/bin/dep2nix --prefix PATH ':' ${binPath}
   '';
   
   meta = with stdenv.lib; {


### PR DESCRIPTION
buildGoPackage in Nixpkgs used to produce a "bin" output, but no
longer does.